### PR TITLE
Implement Air Roll Trainer plugin

### DIFF
--- a/BakkesPluginTemplate.vcxproj
+++ b/BakkesPluginTemplate.vcxproj
@@ -107,7 +107,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="$projectname$.cpp" />
+    <ClCompile Include="plugin.cpp" />
     <ClCompile Include="GuiBase.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -128,11 +128,11 @@
     <ClInclude Include="logging.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="GuiBase.h" />
-    <ClInclude Include="$projectname$.h" />
+    <ClInclude Include="plugin.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
     <ItemGroup>
-    <ResourceCompile Include="$projectname$.rc" />
+    <ResourceCompile Include="plugin.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/BakkesPluginTemplate.vcxproj.filters
+++ b/BakkesPluginTemplate.vcxproj.filters
@@ -75,7 +75,7 @@
     <ClCompile Include="pch.cpp">
       <Filter>PCH</Filter>
     </ClCompile>
-    <ClCompile Include="$projectname$.cpp">
+    <ClCompile Include="plugin.cpp">
       <Filter>Plugin\src</Filter>
     </ClCompile>
     <ClCompile Include="GuiBase.cpp">
@@ -131,7 +131,7 @@
     <ClInclude Include="pch.h">
       <Filter>PCH</Filter>
     </ClInclude>
-    <ClInclude Include="$projectname$.h">
+    <ClInclude Include="plugin.h">
       <Filter>Plugin\header</Filter>
     </ClInclude>
     <ClInclude Include="logging.h">
@@ -142,7 +142,7 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="UpgradeTest.rc">
+    <ResourceCompile Include="plugin.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# BakkesmodPluginTemplate
+# Air Roll Trainer
 
-## Instructions for use
- 1. Download the repo as a zip 
- 2. Move the zip into Documents\Visual Studio 2022\Templates\ProjectTemplates
- 3. Unpack the zip 
- 4. Restart your computer
- 5. Start visual studio. Create a new project and you should see BakkesModPlugin as a project template
- 6. Profit $$$
+Directional air roll practice helper for Rocket League. The plugin slows down the game in Freeplay and Custom Training, draws a live controller overlay, and suggests how you should move your stick to align the car with the ball.
 
-### Video showing every step above (Except the restart)
-[ClickMe](https://youtu.be/Pd3Sa5VWEmc)
+## Features
+
+* **Configurable slowdown:** `art_slowdown_pct` lets you choose how much to slow the simulation (default 60%).
+* **Overlay toggle:** `art_overlay_enabled` hides or shows the controller overlay.
+* **Hint sensitivity:** `art_hint_sensitivity` controls how strong the recommendation must be before the arrow appears.
+* **Enable switch:** `art_enabled` turns the trainer on or off and restores normal game speed when disabled.
+
+## Building
+
+Build the Visual Studio project in Release mode. Copy the produced `AirRollTrainer.dll` to `BakkesMod\plugins` and add `AirRollTrainer` to `plugins.cfg`.

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1,49 +1,314 @@
 #include "pch.h"
-#include "$projectname$.h"
+#include "plugin.h"
 
+#include "bakkesmod/wrappers/BallWrapper.h"
+#include "bakkesmod/wrappers/CanvasWrapper.h"
+#include "bakkesmod/wrappers/ControllerInput.h"
+#include "bakkesmod/wrappers/GameEvent/GameEventWrapper.h"
+#include "bakkesmod/wrappers/ServerWrapper.h"
+#include "bakkesmod/wrappers/Structs.h"
 
-BAKKESMOD_PLUGIN($projectname$, "write a plugin description here", plugin_version, PLUGINTYPE_FREEPLAY)
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <string>
+
+#include <fmt/format.h>
+
+BAKKESMOD_PLUGIN(AirRollTrainer, "Directional air roll trainer", plugin_version, PLUGINTYPE_FREEPLAY | PLUGINTYPE_CUSTOM_TRAINING)
+
+namespace
+{
+        constexpr float kMinSlowdownPercent = 5.0f;
+        constexpr float kMaxSlowdownPercent = 100.0f;
+        constexpr float kDefaultSlowdownPercent = 60.0f;
+}
 
 std::shared_ptr<CVarManagerWrapper> _globalCvarManager;
 
-void $projectname$::onLoad()
+void AirRollTrainer::onLoad()
 {
-	_globalCvarManager = cvarManager;
-	//LOG("Plugin loaded!");
-	// !! Enable debug logging by setting DEBUG_LOG = true in logging.h !!
-	//DEBUGLOG("$projectname$ debug mode enabled");
+        _globalCvarManager = cvarManager;
 
-	// LOG and DEBUGLOG use fmt format strings https://fmt.dev/latest/index.html
-	//DEBUGLOG("1 = {}, 2 = {}, pi = {}, false != {}", "one", 2, 3.14, true);
+        RegisterCVars();
+        RegisterRendering();
+        ScheduleUpdate();
+}
 
-	//cvarManager->registerNotifier("my_aweseome_notifier", [&](std::vector<std::string> args) {
-	//	LOG("Hello notifier!");
-	//}, "", 0);
+void AirRollTrainer::onUnload()
+{
+        ResetGameSpeed();
 
-	//auto cvar = cvarManager->registerCvar("template_cvar", "hello-cvar", "just a example of a cvar");
-	//auto cvar2 = cvarManager->registerCvar("template_cvar2", "0", "just a example of a cvar with more settings", true, true, -10, true, 10 );
+        if (gameWrapper)
+        {
+                gameWrapper->UnregisterDrawables(this);
+        }
+}
 
-	//cvar.addOnValueChanged([this](std::string cvarName, CVarWrapper newCvar) {
-	//	LOG("the cvar with name: {} changed", cvarName);
-	//	LOG("the new value is: {}", newCvar.getStringValue());
-	//});
+void AirRollTrainer::RegisterCVars()
+{
+        enabled_ = std::make_shared<bool>(true);
 
-	//cvar2.addOnValueChanged(std::bind(&$projectname$::YourPluginMethod, this, _1, _2));
+        auto enabledCvar = cvarManager->registerCvar(
+                "art_enabled",
+                "1",
+                "Enable or disable the air roll trainer",
+                true,
+                true,
+                0.f,
+                true,
+                1.f);
+        enabledCvar.bindTo(enabled_);
 
-	// enabled decleared in the header
-	//enabled = std::make_shared<bool>(false);
-	//cvarManager->registerCvar("TEMPLATE_Enabled", "0", "Enable the TEMPLATE plugin", true, true, 0, true, 1).bindTo(enabled);
+        slowdownCvar_ = cvarManager->registerCvar(
+                "art_slowdown_pct",
+                fmt::format("{:.0f}", kDefaultSlowdownPercent),
+                "Slowdown percentage applied to the game speed",
+                true,
+                true,
+                kMinSlowdownPercent,
+                true,
+                kMaxSlowdownPercent);
 
-	//cvarManager->registerNotifier("NOTIFIER", [this](std::vector<std::string> params){FUNCTION();}, "DESCRIPTION", PERMISSION_ALL);
-	//cvarManager->registerCvar("CVAR", "DEFAULTVALUE", "DESCRIPTION", true, true, MINVAL, true, MAXVAL);//.bindTo(CVARVARIABLE);
-	//gameWrapper->HookEvent("FUNCTIONNAME", std::bind(&TEMPLATE::FUNCTION, this));
-	//gameWrapper->HookEventWithCallerPost<ActorWrapper>("FUNCTIONNAME", std::bind(&$projectname$::FUNCTION, this, _1, _2, _3));
-	//gameWrapper->RegisterDrawable(bind(&TEMPLATE::Render, this, std::placeholders::_1));
+        overlayCvar_ = cvarManager->registerCvar(
+                "art_overlay_enabled",
+                "1",
+                "Show the input and guidance overlay",
+                true,
+                true,
+                0.f,
+                true,
+                1.f);
 
+        hintSensitivityCvar_ = cvarManager->registerCvar(
+                "art_hint_sensitivity",
+                "0.25",
+                "Minimum recommendation strength before drawing the arrow",
+                true,
+                true,
+                0.f,
+                true,
+                1.f);
 
-	//gameWrapper->HookEvent("Function TAGame.Ball_TA.Explode", [this](std::string eventName) {
-	//	LOG("Your hook got called and the ball went POOF");
-	//});
-	// You could also use std::bind here
-	//gameWrapper->HookEvent("Function TAGame.Ball_TA.Explode", std::bind(&$projectname$::YourPluginMethod, this);
+        enabledCvar.addOnValueChanged([this](std::string, CVarWrapper wrapper) {
+                if (!wrapper.getBoolValue())
+                {
+                        ResetGameSpeed();
+                }
+        });
+
+        slowdownCvar_.addOnValueChanged([this](std::string, CVarWrapper) {
+                ApplyGameSpeed();
+        });
+}
+
+void AirRollTrainer::RegisterRendering()
+{
+        if (!gameWrapper || drawRegistered_)
+        {
+                return;
+        }
+
+        gameWrapper->RegisterDrawable(std::bind(&AirRollTrainer::Render, this, std::placeholders::_1));
+        drawRegistered_ = true;
+}
+
+void AirRollTrainer::ScheduleUpdate()
+{
+        if (!gameWrapper)
+        {
+                return;
+        }
+
+        gameWrapper->SetTimeout([this](GameWrapper*) {
+                UpdateTrainer();
+                ScheduleUpdate();
+        }, 0.02f);
+}
+
+void AirRollTrainer::UpdateTrainer()
+{
+        if (!gameWrapper || !enabled_ || !*enabled_)
+        {
+                return;
+        }
+
+        if (!gameWrapper->IsInFreeplay() && !gameWrapper->IsInCustomTraining())
+        {
+                ResetGameSpeed();
+                return;
+        }
+
+        CarWrapper car = gameWrapper->GetLocalCar();
+        if (!car)
+        {
+                return;
+        }
+
+        CaptureInput(car);
+        UpdateRecommendation(car);
+        ApplyGameSpeed();
+}
+
+void AirRollTrainer::ApplyGameSpeed()
+{
+        if (!gameWrapper || !enabled_ || !*enabled_)
+        {
+                return;
+        }
+
+        if (!gameWrapper->IsInFreeplay() && !gameWrapper->IsInCustomTraining())
+        {
+                return;
+        }
+
+        ServerWrapper server = gameWrapper->GetGameEventAsServer();
+        if (!server)
+        {
+                return;
+        }
+
+        const float slowdown = std::clamp(slowdownCvar_.getFloatValue(), kMinSlowdownPercent, kMaxSlowdownPercent);
+        const float gameSpeed = slowdown / 100.0f;
+        server.SetGameSpeed(gameSpeed);
+}
+
+void AirRollTrainer::ResetGameSpeed()
+{
+        if (!gameWrapper)
+        {
+                return;
+        }
+
+        ServerWrapper server = gameWrapper->GetGameEventAsServer();
+        if (server)
+        {
+                server.SetGameSpeed(1.0f);
+        }
+}
+
+void AirRollTrainer::CaptureInput(const CarWrapper& car)
+{
+        ControllerInput input = car.GetInput();
+        lastInput_ = input;
+}
+
+void AirRollTrainer::UpdateRecommendation(const CarWrapper& car)
+{
+        BallWrapper ball = gameWrapper->GetBall();
+        if (!ball)
+        {
+                recommendedStick_ = {};
+                recommendedRoll_ = 0.f;
+                return;
+        }
+
+        const Vector carLocation = car.GetLocation();
+        const Vector ballLocation = ball.GetLocation();
+        Vector toBall = ballLocation - carLocation;
+
+        if (toBall.magnitude() < 1.f)
+        {
+                recommendedStick_ = {};
+                recommendedRoll_ = 0.f;
+                return;
+        }
+
+        toBall.normalize();
+
+        const Vector carForward = car.GetForwardVector();
+        const Vector carRight = car.GetRightVector();
+        const Vector carUp = car.GetUpVector();
+
+        const Vector rotationAxis = carForward.cross(toBall);
+
+        const float yawError = rotationAxis.dot(carUp);
+        const float pitchError = rotationAxis.dot(carRight);
+        const float rollError = rotationAxis.dot(carForward);
+
+        const float maxComponent = std::max({ std::abs(yawError), std::abs(pitchError), 1e-3f });
+
+        recommendedStick_.x = std::clamp(yawError / maxComponent, -1.f, 1.f);
+        recommendedStick_.y = std::clamp(-pitchError / maxComponent, -1.f, 1.f);
+        recommendedRoll_ = std::clamp(rollError, -1.f, 1.f);
+}
+
+void AirRollTrainer::Render(CanvasWrapper canvas)
+{
+        if (overlayCvar_.IsNull() || hintSensitivityCvar_.IsNull())
+        {
+                return;
+        }
+
+        if (!enabled_ || !*enabled_)
+        {
+                return;
+        }
+
+        if (!overlayCvar_.getBoolValue())
+        {
+                return;
+        }
+
+        if (!gameWrapper->IsInFreeplay() && !gameWrapper->IsInCustomTraining())
+        {
+                return;
+        }
+
+        const Vector2 canvasSize = canvas.GetSize();
+        const float boxSize = 200.f;
+        const Vector2 origin{
+                static_cast<int>(canvasSize.X - boxSize - 40.f),
+                static_cast<int>(canvasSize.Y - boxSize - 160.f)
+        };
+        const Vector2 boxDimensions{ static_cast<int>(boxSize), static_cast<int>(boxSize) };
+        const Vector2 center{
+                origin.X + boxDimensions.X / 2,
+                origin.Y + boxDimensions.Y / 2
+        };
+
+        canvas.SetColor(0, 0, 0, 140);
+        canvas.FillBox(origin, boxDimensions);
+
+        canvas.SetColor(255, 255, 255, 220);
+        canvas.DrawBox(origin, boxDimensions);
+
+        const float half = static_cast<float>(boxDimensions.X) * 0.5f - 10.f;
+        const Vector2 yawPitchIndicator{
+                static_cast<int>(center.X + lastInput_.Yaw * half),
+                static_cast<int>(center.Y - lastInput_.Pitch * half)
+        };
+
+        canvas.SetColor(120, 200, 255, 255);
+        canvas.DrawLine(center, yawPitchIndicator);
+        canvas.FillBox({ yawPitchIndicator.X - 3, yawPitchIndicator.Y - 3 }, { 6, 6 });
+
+        const float recommendationStrength = std::sqrt(recommendedStick_.x * recommendedStick_.x + recommendedStick_.y * recommendedStick_.y);
+        if (recommendationStrength >= hintSensitivityCvar_.getFloatValue())
+        {
+                const Vector2 recommendedTarget{
+                        static_cast<int>(center.X + recommendedStick_.x * half),
+                        static_cast<int>(center.Y - recommendedStick_.y * half)
+                };
+
+                canvas.SetColor(255, 140, 0, 255);
+                canvas.DrawLine(center, recommendedTarget);
+                canvas.FillBox({ recommendedTarget.X - 4, recommendedTarget.Y - 4 }, { 8, 8 });
+        }
+
+        const int textX = origin.X;
+        int textY = origin.Y + boxDimensions.Y + 10;
+        const auto drawStat = [&](const std::string& label, float value) {
+                const std::string line = fmt::format("{}: {:.2f}", label, value);
+                canvas.DrawString({ textX, textY }, line, 1.0f, 1.0f);
+                textY += 18;
+        };
+
+        canvas.SetColor(255, 255, 255, 255);
+        drawStat("Throttle", lastInput_.Throttle);
+        drawStat("Steer", lastInput_.Steer);
+        drawStat("Pitch", lastInput_.Pitch);
+        drawStat("Yaw", lastInput_.Yaw);
+        drawStat("Roll", lastInput_.Roll);
+        drawStat("Roll hint", recommendedRoll_);
 }

--- a/plugin.h
+++ b/plugin.h
@@ -2,25 +2,46 @@
 
 #include "GuiBase.h"
 #include "bakkesmod/plugin/bakkesmodplugin.h"
-#include "bakkesmod/plugin/pluginwindow.h"
-#include "bakkesmod/plugin/PluginSettingsWindow.h"
+#include "bakkesmod/wrappers/CarWrapper.h"
+#include "bakkesmod/wrappers/CanvasWrapper.h"
+#include "bakkesmod/wrappers/ControllerInput.h"
+#include "bakkesmod/wrappers/GameWrapper.h"
+#include "bakkesmod/wrappers/cvarwrapper.h"
 
 #include "version.h"
+
 constexpr auto plugin_version = stringify(VERSION_MAJOR) "." stringify(VERSION_MINOR) "." stringify(VERSION_PATCH) "." stringify(VERSION_BUILD);
 
-
-class $projectname$: public BakkesMod::Plugin::BakkesModPlugin
-	//,public SettingsWindowBase // Uncomment if you wanna render your own tab in the settings menu
-	//,public PluginWindowBase // Uncomment if you want to render your own plugin window
+class AirRollTrainer final : public BakkesMod::Plugin::BakkesModPlugin
 {
-
-	//std::shared_ptr<bool> enabled;
-
-	//Boilerplate
-	void onLoad() override;
-	//void onUnload() override; // Uncomment and implement if you need a unload method
-
 public:
-	//void RenderSettings() override; // Uncomment if you wanna render your own tab in the settings menu
-	//void RenderWindow() override; // Uncomment if you want to render your own plugin window
+        void onLoad() override;
+        void onUnload() override;
+
+private:
+        struct StickVector
+        {
+                float x{ 0.f };
+                float y{ 0.f };
+        };
+
+        void RegisterCVars();
+        void RegisterRendering();
+        void ScheduleUpdate();
+        void UpdateTrainer();
+        void ApplyGameSpeed();
+        void ResetGameSpeed();
+        void CaptureInput(const CarWrapper& car);
+        void UpdateRecommendation(const CarWrapper& car);
+        void Render(CanvasWrapper canvas);
+
+        std::shared_ptr<bool> enabled_;
+        CVarWrapper slowdownCvar_;
+        CVarWrapper overlayCvar_;
+        CVarWrapper hintSensitivityCvar_;
+
+        ControllerInput lastInput_{};
+        StickVector recommendedStick_{};
+        float recommendedRoll_{ 0.f };
+        bool drawRegistered_{ false };
 };

--- a/plugin.rc
+++ b/plugin.rc
@@ -50,7 +50,7 @@ END
 
 
 /////////////////////////////////////////////////////////////////////////////
-// Norwegian Bokmål (Norway) resources
+// Norwegian BokmÃ¥l (Norway) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NOR)
 LANGUAGE LANG_NORWEGIAN, SUBLANG_NORWEGIAN_BOKMAL
@@ -78,13 +78,13 @@ BEGIN
     BEGIN
         BLOCK "041404b0"
         BEGIN
-            VALUE "CompanyName", "TODO: <Company name>"
-            VALUE "FileDescription", "TODO: <File description>"
+            VALUE "CompanyName", "Community"
+            VALUE "FileDescription", "Directional air roll practice helper"
             VALUE "FileVersion", stringify(VERSION_MAJOR) "." stringify(VERSION_MINOR) "." stringify(VERSION_PATCH) "." stringify(VERSION_BUILD)
-            VALUE "InternalName", "$projectname$.dll"
+            VALUE "InternalName", "AirRollTrainer.dll"
             VALUE "LegalCopyright", "Copyright (C) 2020"
-            VALUE "OriginalFilename", "$projectname$.dll"
-            VALUE "ProductName", "TODO: <Product name>"
+            VALUE "OriginalFilename", "AirRollTrainer.dll"
+            VALUE "ProductName", "Air Roll Trainer"
             VALUE "ProductVersion", stringify(VERSION_MAJOR) "." stringify(VERSION_MINOR) "." stringify(VERSION_PATCH) "." stringify(VERSION_BUILD)
         END
     END
@@ -94,7 +94,7 @@ BEGIN
     END
 END
 
-#endif    // Norwegian Bokmål (Norway) resources
+#endif    // Norwegian BokmÃ¥l (Norway) resources
 /////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
## Summary
- replace the template plugin with the new `AirRollTrainer` implementation that slows Freeplay/Custom Training and surfaces controller input
- render an on-screen controller overlay with live input values and recommended stick/roll adjustments toward the ball
- expose console variables for enabling the trainer, tuning slowdown, and hint sensitivity while updating project metadata and documentation

## Testing
- not run (plugin code only)


------
https://chatgpt.com/codex/tasks/task_e_68dc177b0f508328a6363b6b6972ab9f