### PR TITLE
Fix CarWrapper include usage

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -5,6 +5,7 @@
 #include "bakkesmod/wrappers/CanvasWrapper.h"
 #include "bakkesmod/wrappers/ControllerInput.h"
 #include "bakkesmod/wrappers/GameEvent/GameEventWrapper.h"
+#include "bakkesmod/wrappers/VehicleWrapper.h"
 #include "bakkesmod/wrappers/ServerWrapper.h"
 #include "bakkesmod/wrappers/Structs.h"
 

--- a/plugin.h
+++ b/plugin.h
@@ -2,7 +2,6 @@
 
 #include "GuiBase.h"
 #include "bakkesmod/plugin/bakkesmodplugin.h"
-#include "bakkesmod/wrappers/CarWrapper.h"
 #include "bakkesmod/wrappers/CanvasWrapper.h"
 #include "bakkesmod/wrappers/ControllerInput.h"
 #include "bakkesmod/wrappers/GameWrapper.h"
@@ -11,6 +10,8 @@
 #include "version.h"
 
 constexpr auto plugin_version = stringify(VERSION_MAJOR) "." stringify(VERSION_MINOR) "." stringify(VERSION_PATCH) "." stringify(VERSION_BUILD);
+
+class CarWrapper;
 
 class AirRollTrainer final : public BakkesMod::Plugin::BakkesModPlugin
 {


### PR DESCRIPTION
### Motivation
- Resolve missing include error for `bakkesmod/wrappers/CarWrapper.h` observed during build.
- Reduce header dependencies in `plugin.h` by avoiding direct inclusion of wrapper headers in the public plugin header.
- Ensure the translation unit that needs the full `CarWrapper` definition receives it in the `.cpp` file.

### Description
- Removed `#include "bakkesmod/wrappers/CarWrapper.h"` from `plugin.h` and added a forward declaration `class CarWrapper;` in its place.
- Added `#include "bakkesmod/wrappers/VehicleWrapper.h"` to `plugin.cpp` so the implementation unit has the `CarWrapper`/vehicle definition.
- Kept function signatures using `const CarWrapper&` in `plugin.h` unchanged so callers are unaffected.
- Modified only `plugin.h` and `plugin.cpp` to implement the include/forward-declare fix.

### Testing
- No automated tests were run for this change.
- The change was committed; a compilation/build verification was not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f3ab0ff88328953e49e31d92622a)