### PR TITLE
Fix missing ControllerInput include

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -3,7 +3,6 @@
 
 #include "bakkesmod/wrappers/BallWrapper.h"
 #include "bakkesmod/wrappers/CanvasWrapper.h"
-#include "bakkesmod/wrappers/ControllerInput.h"
 #include "bakkesmod/wrappers/GameEvent/GameEventWrapper.h"
 #include "bakkesmod/wrappers/VehicleWrapper.h"
 #include "bakkesmod/wrappers/ServerWrapper.h"

--- a/plugin.h
+++ b/plugin.h
@@ -3,8 +3,8 @@
 #include "GuiBase.h"
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 #include "bakkesmod/wrappers/CanvasWrapper.h"
-#include "bakkesmod/wrappers/ControllerInput.h"
 #include "bakkesmod/wrappers/GameWrapper.h"
+#include "bakkesmod/wrappers/Structs.h"
 #include "bakkesmod/wrappers/cvarwrapper.h"
 
 #include "version.h"


### PR DESCRIPTION
### Motivation
- The build failed with "Cannot open include file: 'bakkesmod/wrappers/ControllerInput.h'" so the plugin could not resolve `ControllerInput`.
- Prefer using the SDK-provided wrapper types grouped in `Structs.h` to resolve those definitions.
- Remove redundant includes from implementation to avoid duplicate/missing header issues.

### Description
- Removed `#include "bakkesmod/wrappers/ControllerInput.h"` from `plugin.h` and replaced it with `#include "bakkesmod/wrappers/Structs.h"` so `ControllerInput` resolves via the SDK.
- Dropped the redundant `#include "bakkesmod/wrappers/ControllerInput.h"` from `plugin.cpp`.
- Kept all existing logic unchanged; this is purely an include/header fix to resolve compilation errors.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f48bda6083289bf008a292f85acd)