### PR TITLE
Add fallback include for BakkesMod structs header

### DIFF
--- a/BakkesModStructs.h
+++ b/BakkesModStructs.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#if defined(__has_include)
+#  if __has_include("bakkesmod/wrappers/Structs.h")
+#    include "bakkesmod/wrappers/Structs.h"
+#  elif __has_include("bakkesmod/wrappers/structs.h")
+#    include "bakkesmod/wrappers/structs.h"
+#  else
+#    error "Unable to locate BakkesMod structs header. Ensure the BakkesMod SDK include path is configured."
+#  endif
+#else
+#  include "bakkesmod/wrappers/Structs.h"
+#endif

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -6,7 +6,6 @@
 #include "bakkesmod/wrappers/GameEvent/GameEventWrapper.h"
 #include "bakkesmod/wrappers/VehicleWrapper.h"
 #include "bakkesmod/wrappers/ServerWrapper.h"
-#include "bakkesmod/wrappers/Structs.h"
 
 #include <algorithm>
 #include <cmath>

--- a/plugin.h
+++ b/plugin.h
@@ -4,8 +4,9 @@
 #include "bakkesmod/plugin/bakkesmodplugin.h"
 #include "bakkesmod/wrappers/CanvasWrapper.h"
 #include "bakkesmod/wrappers/GameWrapper.h"
-#include "bakkesmod/wrappers/Structs.h"
 #include "bakkesmod/wrappers/cvarwrapper.h"
+
+#include "BakkesModStructs.h"
 
 #include "version.h"
 


### PR DESCRIPTION
### Motivation
- Fix build errors caused by missing `bakkesmod/wrappers/Structs.h` by providing a robust local header that selects the correct SDK header.
- Support variations in SDK packaging or filename casing by checking both `Structs.h` and `structs.h`.
- Provide a clear preprocessor error when the BakkesMod SDK include path is not configured.

### Description
- Add `BakkesModStructs.h` which uses `__has_include` to include `bakkesmod/wrappers/Structs.h` or `bakkesmod/wrappers/structs.h`, and emits `#error` if neither is found.
- Replace direct `#include "bakkesmod/wrappers/Structs.h"` usages with `#include "BakkesModStructs.h"` in `plugin.h` and remove the redundant include from `plugin.cpp`.
- centralize the include workaround so other source files can reliably include the SDK structs via the new header.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f6626d188328af7ccc9e5aecd889)