### PR TITLE
Support Structs.hpp/structs.hpp when locating BakkesMod structs header

### DIFF
--- a/BakkesModStructs.h
+++ b/BakkesModStructs.h
@@ -5,6 +5,10 @@
 #    include "bakkesmod/wrappers/Structs.h"
 #  elif __has_include("bakkesmod/wrappers/structs.h")
 #    include "bakkesmod/wrappers/structs.h"
+#  elif __has_include("bakkesmod/wrappers/Structs.hpp")
+#    include "bakkesmod/wrappers/Structs.hpp"
+#  elif __has_include("bakkesmod/wrappers/structs.hpp")
+#    include "bakkesmod/wrappers/structs.hpp"
 #  else
 #    error "Unable to locate BakkesMod structs header. Ensure the BakkesMod SDK include path is configured."
 #  endif


### PR DESCRIPTION
### Motivation
- Compilation can fail when the BakkesMod SDK exposes the structs header with a `.hpp` extension, causing the existing `#include` checks to miss it and emit an error.
- Provide broader compatibility with different SDK distributions that may use either `.h` or `.hpp` naming conventions.

### Description
- Updated `BakkesModStructs.h` to add `__has_include` checks for `bakkesmod/wrappers/Structs.hpp` and `bakkesmod/wrappers/structs.hpp` and include them when present.
- Preserved existing checks for `Structs.h`/`structs.h` and the fallback include for compilers without `__has_include` support.
- The existing error message remains unchanged if none of the supported headers are found.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695539aed8f48328b7e633c74d6c6d8a)